### PR TITLE
remove nl-portal-app artifact upload/download, since it's not a npm package which needs to be uploaded

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,13 +47,6 @@ jobs:
           path: packages/api/dist/
           retention-days: 1
 
-      - name: "Retain build artifact: app"
-        uses: actions/upload-artifact@v3
-        with:
-          name: nl-portal-app
-          path: packages/app/dist/
-          retention-days: 1
-
       - name: "Retain build artifact: authentication"
         uses: actions/upload-artifact@v3
         with:
@@ -108,12 +101,6 @@ jobs:
         with:
           name: nl-portal-api
           path: packages/api/dist/
-
-      - name: "Restore build artifact: app"
-        uses: actions/download-artifact@v3
-        with:
-          name: nl-portal-app
-          path: packages/app/dist/
 
       - name: "Restore build artifact: authentication"
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Hopefully the last adjustment needed for the cicd. nl-portal-app doesn't have a dist folder and isn't published to the npm registry.