### PR TITLE
Feature/remove documents page

### DIFF
--- a/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
+++ b/packages/user-interface/src/components/current-page-indicator/current-page-indicator.module.scss
@@ -39,7 +39,8 @@
   align-items: center;
 }
 
-.current-page-indicator__heading {
+h5.current-page-indicator__heading {
+  --utrecht-space-around: 0;
   color: var(--nlportal-heading-5-color, hsl(207 80% 35%)) !important;
 }
 

--- a/packages/user-interface/src/components/menu/menu.module.scss
+++ b/packages/user-interface/src/components/menu/menu.module.scss
@@ -31,6 +31,7 @@
   @include breakpoint(tablet) {
     display: block;
     min-width: var(--denhaag-sidenav-min-width);
+    background-color: transparent;
   }
 }
 
@@ -38,6 +39,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  position: fixed;
 }
 
 .menu__header {

--- a/packages/user-interface/src/pages/case/case-page.tsx
+++ b/packages/user-interface/src/pages/case/case-page.tsx
@@ -27,9 +27,14 @@ import {LocaleDate} from '../../components/locale-date';
 interface CasePageProps {
   statusHistoryFacet?: ReactElement;
   statusHistoryBackground?: ReactElement;
+  showDocumentsListLink?: boolean;
 }
 
-const CasePage: FC<CasePageProps> = ({statusHistoryFacet, statusHistoryBackground}) => {
+const CasePage: FC<CasePageProps> = ({
+  statusHistoryFacet,
+  statusHistoryBackground,
+  showDocumentsListLink = false,
+}) => {
   const intl = useIntl();
   const query = useQuery();
   const {hrefLang} = useContext(LocaleContext);
@@ -134,23 +139,26 @@ const CasePage: FC<CasePageProps> = ({statusHistoryFacet, statusHistoryBackgroun
               <Heading3 className={classNames({[styles['case__sub-header']]: !isTablet})}>
                 <FormattedMessage id="pageTitles.documents" />
               </Heading3>
-              {!loading && data?.getZaak?.documenten && data?.getZaak?.documenten.length > 0 && (
-                <div
-                  className={classNames(styles['case__documents-link'], {
-                    [styles['case__documents-link--tablet']]: isTablet,
-                  })}
-                >
-                  <Link
-                    component={RouterLink}
-                    to={getDocumentsUrl(id || '')}
-                    icon={<ArrowRightIcon />}
-                    iconAlign="end"
-                    hrefLang={hrefLang}
+              {showDocumentsListLink &&
+                !loading &&
+                data?.getZaak?.documenten &&
+                data?.getZaak?.documenten.length > 0 && (
+                  <div
+                    className={classNames(styles['case__documents-link'], {
+                      [styles['case__documents-link--tablet']]: isTablet,
+                    })}
                   >
-                    <FormattedMessage id="case.showAllDocuments" />
-                  </Link>
-                </div>
-              )}
+                    <Link
+                      component={RouterLink}
+                      to={getDocumentsUrl(id || '')}
+                      icon={<ArrowRightIcon />}
+                      iconAlign="end"
+                      hrefLang={hrefLang}
+                    >
+                      <FormattedMessage id="case.showAllDocuments" />
+                    </Link>
+                  </div>
+                )}
             </div>
             <DocumentList documents={loading ? undefined : data?.getZaak.documenten} />
           </div>


### PR DESCRIPTION
- Added configuration option which makes it possible to show/hide the 'Show all documents' link on the case detail page. By default, this will be hidden, since the documents page behind that link it doesn't do anything different than the document list on the case detail page right now.
- Fixed a minor backwards compatibility issue with the new sidenav: scrolled over the header on longer pages
- Fixed a minor backwards compatibility issue with the current page indicator: margins where off because of the updated Utrecht CSS dependency.