### PR TITLE
Disable alerts form io

### DIFF
--- a/packages/user-interface/src/pages/task/task-page.tsx
+++ b/packages/user-interface/src/pages/task/task-page.tsx
@@ -150,6 +150,7 @@ const TaskPage = () => {
           submission={submission}
           onChange={setFormSubmission}
           onSubmit={onFormSubmit}
+          options={{noAlerts: true}}
         />
       ) : (
         getSubmittedMessage()


### PR DESCRIPTION
When you submit forms there is a glitch with "submit succes" message. We don't need this alert because of redirect or custom succes message.