### PR TITLE
refactor: add new prop for additional config option on kc instance

### DIFF
--- a/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
+++ b/packages/authentication/src/components/keycloak-wrapper/keycloak-wrapper.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import {ReactKeycloakProvider} from '@react-keycloak/web';
-import Keycloak, {KeycloakConfig, KeycloakInitOptions, KeycloakInstance} from 'keycloak-js';
+import Keycloak, {
+  KeycloakConfig,
+  KeycloakInitOptions,
+  KeycloakInstance,
+  KeycloakOnLoad,
+} from 'keycloak-js';
 import {FC, Fragment, useContext, useState, useEffect} from 'react';
 import jwtDecode from 'jwt-decode';
 import {formatUrlTrailingSlash} from '../../utils';
@@ -13,6 +18,7 @@ interface KeycloakWrapperProps extends KeycloakConfig {
   autoIdleSessionLogout?: boolean;
   idleTimeoutMinutes?: number;
   minValiditySeconds?: number;
+  onLoad?: KeycloakOnLoad;
 }
 
 interface IdleTimerProps {
@@ -75,6 +81,7 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   autoIdleSessionLogout = true,
   idleTimeoutMinutes = 15,
   minValiditySeconds = 30,
+  onLoad = 'login-required',
 }) => {
   const {setKeycloakToken, setDecodedToken} = useContext(KeycloakContext);
   const [authClient] = useState(
@@ -87,14 +94,16 @@ const KeycloakProvider: FC<KeycloakWrapperProps> = ({
   );
   const initOptions: KeycloakInitOptions = {
     checkLoginIframe: false,
-    onLoad: 'login-required',
+    onLoad,
     flow: 'standard',
     redirectUri: formatUrlTrailingSlash(redirectUri, false),
   };
   const decodeToken = (jwtToken: string) => jwtDecode<DecodedToken>(jwtToken);
 
   const updateToken = () => {
-    authClient.updateToken(minValiditySeconds);
+    if (authClient.token) {
+      authClient.updateToken(minValiditySeconds);
+    }
   };
 
   return (


### PR DESCRIPTION
Having a setting to configure the KC instance, so that it is optional to redirect to the KC login screen when user is not authenticated (`login-required`). No instead with `check-sso`, when the user is not authenticated, it wil redirect backt to the app.