### PR TITLE
feat: added authentication methods prop to keycloak context to fix issues after removing bsn/kvk from jwt token

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,35 @@ by default. Possible configuration values are specified in the
 These values are set to the window object by [config.js](./packages/app/public/config.js), which
 also contains the default values for local development.
 
+Another configuration option is the authentication methods, which must include the mapping for the 'middel' claim in the JWT token, and the type of login (person, company, proxy). Example snippet for in the implementation:
+
+```
+...
+const authenticationMethods = {
+  person: ["digid", "machtigen"],
+  company: ["eherkenning", "bewindvoering"],
+  proxy: ["machtigen", "bewindvoering"],
+};
+...
+const App = () => {
+...
+return (
+    <div className={config.THEME_CLASS}>
+      <KeycloakWrapper
+        clientId={config.KEYCLOAK_CLIENT_ID}
+        realm={config.KEYCLOAK_REALM}
+        url={config.KEYCLOAK_URL}
+        redirectUri={config.KEYCLOAK_REDIRECT_URI}
+        authenticationMethods={authenticationMethods}
+      >
+      ...
+      </KeycloakWrapper>
+    </div>
+  );
+};
+...
+```
+
 When starting the app through Docker, these values can be optionally overridden, i.e.:
 
 ```

--- a/packages/app/public/config.js
+++ b/packages/app/public/config.js
@@ -1,5 +1,5 @@
 window.KEYCLOAK_URL = 'http://localhost:8082/auth';
-window.KEYCLOAK_REALM = 'master';
+window.KEYCLOAK_REALM = 'nlportal';
 window.KEYCLOAK_CLIENT_ID = 'gzac-portal';
 window.KEYCLOAK_REDIRECT_URI = 'http://localhost:3000/keycloak/callback';
 window.GRAPHQL_URI = 'http://localhost:8090/graphql';

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -15,6 +15,12 @@ import React from "react";
 import { menuItems } from "./constants/menu-items";
 import { paths } from "./constants/paths";
 
+const authenticationMethods = {
+  person: ["digid", "machtigen"],
+  company: ["eherkenning", "bewindvoering"],
+  proxy: ["machtigen", "bewindvoering"],
+};
+
 const App = () => {
   if (!config.KEYCLOAK_CLIENT_ID) {
     console.log("KEYCLOAK_CLIENT_ID is not set");
@@ -53,6 +59,7 @@ const App = () => {
         realm={config.KEYCLOAK_REALM}
         url={config.KEYCLOAK_URL}
         redirectUri={config.KEYCLOAK_REDIRECT_URI}
+        authenticationMethods={authenticationMethods}
       >
         {/* TODO: Moved StrictMode, because of Keycloak - React 18: https://github.com/react-keycloak/react-keycloak/issues/182 */}
         <React.StrictMode>

--- a/packages/authentication/src/components/KeycloakWrapper.tsx
+++ b/packages/authentication/src/components/KeycloakWrapper.tsx
@@ -13,6 +13,12 @@ import { formatUrlTrailingSlash } from "../utils/format-url-trailing-slash";
 import KeycloakContext from "../contexts/KeycloakContext";
 import { DecodedToken } from "../interfaces/decoded-token";
 
+export type AuthenticationMethods = {
+  person?: string[];
+  company?: string[];
+  proxy?: string[];
+};
+
 interface KeycloakWrapperProps extends KeycloakConfig {
   children: React.ReactNode;
   redirectUri: string;
@@ -21,6 +27,7 @@ interface KeycloakWrapperProps extends KeycloakConfig {
   idleTimeoutMinutes?: number;
   minValiditySeconds?: number;
   onLoad?: KeycloakOnLoad;
+  authenticationMethods?: AuthenticationMethods;
 }
 
 interface IdleTimerProps {
@@ -166,6 +173,7 @@ const KeycloakWrapper: FC<KeycloakWrapperProps> = (props) => {
         setKeycloakToken,
         decodedToken,
         setDecodedToken,
+        authenticationMethods: props.authenticationMethods,
       }}
     >
       <KeycloakProvider {...props} />

--- a/packages/authentication/src/contexts/KeycloakContext.ts
+++ b/packages/authentication/src/contexts/KeycloakContext.ts
@@ -1,12 +1,14 @@
 import * as React from "react";
 import { Dispatch, SetStateAction } from "react";
 import { DecodedToken } from "../interfaces/decoded-token";
+import { AuthenticationMethods } from "../components/KeycloakWrapper";
 
 interface KeycloakContextInterface {
   keycloakToken: string;
   setKeycloakToken: (token: string) => void;
   decodedToken: DecodedToken | undefined;
   setDecodedToken: Dispatch<SetStateAction<DecodedToken | undefined>>;
+  authenticationMethods?: AuthenticationMethods;
 }
 
 const KeycloakContext = React.createContext<KeycloakContextInterface>(

--- a/packages/authentication/src/interfaces/decoded-token.ts
+++ b/packages/authentication/src/interfaces/decoded-token.ts
@@ -1,5 +1,3 @@
 export interface DecodedToken {
-  aanvrager?: { kvk?: string; bsn?: string };
-  gemachtigde?: { kvk?: string; bsn?: string };
   middel?: string;
 }

--- a/packages/authentication/src/interfaces/decoded-token.ts
+++ b/packages/authentication/src/interfaces/decoded-token.ts
@@ -1,4 +1,5 @@
 export interface DecodedToken {
   aanvrager?: { kvk?: string; bsn?: string };
   gemachtigde?: { kvk?: string; bsn?: string };
+  middel?: string;
 }

--- a/packages/user-interface/src/hooks/useUserInfo.tsx
+++ b/packages/user-interface/src/hooks/useUserInfo.tsx
@@ -20,19 +20,19 @@ export const useUserInfo = () => {
     loadGemachtigde,
     { loading: gemachtigdeLoading, data: gemachtigdeData },
   ] = useGetGemachtigdeLazyQuery();
-  const { decodedToken } = useContext(KeycloakContext);
+  const { decodedToken, authenticationMethods } = useContext(KeycloakContext);
   const isLoading = persoonLoading || bedrijfLoading || gemachtigdeLoading;
 
   useEffect(() => {
-    if (decodedToken) {
-      if (decodedToken.aanvrager?.bsn) {
+    if (decodedToken && authenticationMethods) {
+      if (authenticationMethods.person?.includes(decodedToken.middel)) {
         setIsPerson(true);
         loadPersoon();
-      } else if (decodedToken.aanvrager?.kvk) {
+      } else if (authenticationMethods.company?.includes(decodedToken.middel)) {
         setIsPerson(false);
         loadBedrijf();
       }
-      if (decodedToken.gemachtigde) {
+      if (authenticationMethods.proxy?.includes(decodedToken.middel)) {
         setisVolmachtLogin(true);
         loadGemachtigde();
       }
@@ -41,21 +41,21 @@ export const useUserInfo = () => {
 
   useEffect(() => {
     const name = getNameString(persoonData?.getPersoon?.naam);
-    if (decodedToken?.gemachtigde) {
+    if (authenticationMethods?.proxy?.includes(decodedToken?.middel)) {
       setVolmachtgever(name);
     } else {
       setUserName(name);
     }
-  }, [persoonData, decodedToken?.gemachtigde]);
+  }, [persoonData, decodedToken?.middel, authenticationMethods?.proxy]);
 
   useEffect(() => {
     const name = bedrijfData?.getBedrijf?.naam || "";
-    if (decodedToken?.gemachtigde) {
+    if (authenticationMethods?.proxy?.includes(decodedToken?.middel)) {
       setVolmachtgever(name);
     } else {
       setUserName(name);
     }
-  }, [bedrijfData, decodedToken?.gemachtigde]);
+  }, [bedrijfData, decodedToken?.middel, authenticationMethods?.proxy]);
 
   useEffect(() => {
     if (gemachtigdeData?.getGemachtigde?.persoon) {

--- a/packages/user-interface/src/hooks/useUserInfo.tsx
+++ b/packages/user-interface/src/hooks/useUserInfo.tsx
@@ -25,14 +25,17 @@ export const useUserInfo = () => {
 
   useEffect(() => {
     if (decodedToken && authenticationMethods) {
-      if (authenticationMethods.person?.includes(decodedToken.middel)) {
+      const authenticationMethod = decodedToken.middel || "";
+      if (authenticationMethods.person?.includes(authenticationMethod)) {
         setIsPerson(true);
         loadPersoon();
-      } else if (authenticationMethods.company?.includes(decodedToken.middel)) {
+      } else if (
+        authenticationMethods.company?.includes(authenticationMethod)
+      ) {
         setIsPerson(false);
         loadBedrijf();
       }
-      if (authenticationMethods.proxy?.includes(decodedToken.middel)) {
+      if (authenticationMethods.proxy?.includes(authenticationMethod)) {
         setisVolmachtLogin(true);
         loadGemachtigde();
       }
@@ -41,7 +44,8 @@ export const useUserInfo = () => {
 
   useEffect(() => {
     const name = getNameString(persoonData?.getPersoon?.naam);
-    if (authenticationMethods?.proxy?.includes(decodedToken?.middel)) {
+    const authenticationMethod = decodedToken?.middel || "";
+    if (authenticationMethods?.proxy?.includes(authenticationMethod)) {
       setVolmachtgever(name);
     } else {
       setUserName(name);
@@ -50,7 +54,8 @@ export const useUserInfo = () => {
 
   useEffect(() => {
     const name = bedrijfData?.getBedrijf?.naam || "";
-    if (authenticationMethods?.proxy?.includes(decodedToken?.middel)) {
+    const authenticationMethod = decodedToken?.middel || "";
+    if (authenticationMethods?.proxy?.includes(authenticationMethod)) {
       setVolmachtgever(name);
     } else {
       setUserName(name);


### PR DESCRIPTION
Het verwijderen van het bsn/kvk uit de nl-portal leidt tot problemen met het ophalen van persoons-/bedrijfsgegevens. Het bsn en kvk veld werd gebruikt om te bepalen welke gegevens opgehaald moeten worden. 

Bij Den Haag is er een 'middel' veld toegevoegd aan het JWT token, welke de waarde van het inlogmiddel krijgt. Op basis daarvan, kan dan bepaald worden of een persoon of bedrijf ingelogd is, en of er eventueel met volmacht ingelogd is.