### PR TITLE
Theme slug & productType

### DIFF
--- a/packages/app/src/pages/ThemeSampleDetailPage.tsx
+++ b/packages/app/src/pages/ThemeSampleDetailPage.tsx
@@ -6,12 +6,12 @@ import {
 } from "@nl-portal/nl-portal-user-interface";
 
 const ThemeSampleDetailPage = () => {
-  const type = "sample";
+  const slug = "sample";
   const loading = false;
 
   return (
     <ThemeDetailsPage
-      type={type}
+      slug={slug}
       loading={loading}
       titleTranslationId="Keukenhoflaan 133"
       links={[

--- a/packages/app/src/pages/ThemeSampleListPage.tsx
+++ b/packages/app/src/pages/ThemeSampleListPage.tsx
@@ -2,10 +2,10 @@ import { paths } from "../constants/paths";
 import { TableList, ThemeSubPage } from "@nl-portal/nl-portal-user-interface";
 
 const ThemeSampleListPage = () => {
-  const type = "sample";
+  const slug = "sample";
 
   return (
-    <ThemeSubPage type={type} titleTranslationId="Voorbeeldcontracten">
+    <ThemeSubPage slug={slug} titleTranslationId="Voorbeeldcontracten">
       <TableList
         titleTranslationId={null}
         headers={["Adres", "Kadastrale gegevens", "Contractnummer"]}

--- a/packages/app/src/pages/ThemeSampleOverviewPage.tsx
+++ b/packages/app/src/pages/ThemeSampleOverviewPage.tsx
@@ -5,18 +5,19 @@ import {
 import { paths } from "../constants/paths";
 
 const ThemeSampleOverviewPage = () => {
-  const type = "sample";
+  const slug = "sample";
+  const productType = "erfpacht";
   const loading = false;
   const contractsLength = 5;
   const contractsTotal = 12;
 
   return (
-    <ThemeOverviewPage type={type} loading={loading}>
+    <ThemeOverviewPage slug={slug} productType={productType} loading={loading}>
       <TableList
         loading={loading}
-        titleTranslationId={`theme.${type}.listTitle`}
-        readMoreTranslationId={`theme.${type}.listViewAll`}
-        readMoreLink={paths.themeSub(type, "contracten")}
+        titleTranslationId={`theme.${slug}.listTitle`}
+        readMoreTranslationId={`theme.${slug}.listViewAll`}
+        readMoreLink={paths.themeSub(slug, "contracten")}
         totalAmount={
           contractsTotal > contractsLength ? contractsTotal : undefined
         }

--- a/packages/user-interface/src/pages/ThemeDetailsPage.tsx
+++ b/packages/user-interface/src/pages/ThemeDetailsPage.tsx
@@ -10,7 +10,7 @@ import CasesList from "../components/CasesList";
 import LinksList from "../components/LinksList";
 
 interface Props {
-  type: string;
+  slug: string;
   loading?: boolean;
   titleTranslationId?: string;
   tasks?: Taak[];
@@ -22,9 +22,9 @@ interface Props {
 }
 
 const ThemeDetailsPage = ({
-  type,
+  slug,
   loading,
-  titleTranslationId = `pageTitles.${type}`,
+  titleTranslationId = `pageTitles.${slug}`,
   tasks,
   tasksError,
   links,
@@ -38,7 +38,7 @@ const ThemeDetailsPage = ({
   return (
     <PageGrid>
       <div>
-        <BackLink routePath={paths.themeOverview(type)} />
+        <BackLink routePath={paths.themeOverview(slug)} />
         <PageHeader
           loading={loading}
           title={intl.formatMessage({ id: titleTranslationId })}

--- a/packages/user-interface/src/pages/ThemeOverviewPage.tsx
+++ b/packages/user-interface/src/pages/ThemeOverviewPage.tsx
@@ -43,7 +43,11 @@ const ThemeOverviewPage = ({
     loading: casesLoading,
     error: casesError,
   } = useGetProductZakenQuery({
-    variables: { productName: productType, pageSize: fetchCasesLength },
+    variables: {
+      productName: productType,
+      pageSize: fetchCasesLength,
+      isOpen: true,
+    },
     skip: !fetchCasesLength,
   });
 

--- a/packages/user-interface/src/pages/ThemeOverviewPage.tsx
+++ b/packages/user-interface/src/pages/ThemeOverviewPage.tsx
@@ -11,7 +11,8 @@ import {
 } from "@nl-portal/nl-portal-api";
 
 interface Props {
-  type: string;
+  slug: string;
+  productType: string;
   loading?: boolean;
   showTasks?: boolean;
   fetchTasksLength?: number;
@@ -21,7 +22,8 @@ interface Props {
 }
 
 const ThemeOverviewPage = ({
-  type,
+  slug,
+  productType,
   loading: loadingProp,
   fetchTasksLength = 5,
   fetchCasesLength = 4,
@@ -33,7 +35,7 @@ const ThemeOverviewPage = ({
     loading: taskLoading,
     error: taskError,
   } = useGetProductTakenQuery({
-    variables: { productName: type, pageSize: fetchTasksLength },
+    variables: { productName: productType, pageSize: fetchTasksLength },
     skip: !fetchTasksLength,
   });
   const {
@@ -41,7 +43,7 @@ const ThemeOverviewPage = ({
     loading: casesLoading,
     error: casesError,
   } = useGetProductZakenQuery({
-    variables: { productName: type, pageSize: fetchCasesLength, isOpen: true },
+    variables: { productName: productType, pageSize: fetchCasesLength },
     skip: !fetchCasesLength,
   });
 
@@ -51,7 +53,7 @@ const ThemeOverviewPage = ({
 
   return (
     <PageGrid>
-      <PageHeader title={intl.formatMessage({ id: `pageTitles.${type}` })} />
+      <PageHeader title={intl.formatMessage({ id: `pageTitles.${slug}` })} />
       {Boolean(fetchTasksLength) && (
         <TasksList loading={loading} error={Boolean(taskError)} tasks={tasks} />
       )}

--- a/packages/user-interface/src/pages/ThemeSubPage.tsx
+++ b/packages/user-interface/src/pages/ThemeSubPage.tsx
@@ -6,14 +6,14 @@ import { useOutletContext } from "react-router-dom";
 import { RouterOutletContext } from "../contexts/RouterOutletContext";
 
 interface Props {
-  type: string;
+  slug: string;
   titleTranslationId?: string;
   children?: React.ReactNode;
 }
 
 const ThemeSubPage = ({
-  type,
-  titleTranslationId = `pageTitles.${type}`,
+  slug,
+  titleTranslationId = `pageTitles.${slug}`,
   children,
 }: Props) => {
   const intl = useIntl();
@@ -22,7 +22,7 @@ const ThemeSubPage = ({
   return (
     <PageGrid>
       <div>
-        <BackLink routePath={paths.themeOverview(type)} />
+        <BackLink routePath={paths.themeOverview(slug)} />
         <PageHeader title={intl.formatMessage({ id: titleTranslationId })} />
       </div>
       {children}


### PR DESCRIPTION
Type vervangen voor slug en productType:

- Slug: wordt gebruik op code niveau en ook de route/url
- ProductType: ophalen van juiste product via api