### PR TITLE
Formio multiline textarea

### DIFF
--- a/packages/user-interface/src/pages/TaskPage.module.scss
+++ b/packages/user-interface/src/pages/TaskPage.module.scss
@@ -3,5 +3,8 @@
     /* stylelint-disable no-invalid-position-at-import-rule */
     @import "bootstrap/dist/css/bootstrap";
     /* stylelint-enable no-invalid-position-at-import-rule */
+    .formio-editor-read-only-content {
+      white-space: pre-wrap;
+    }
   }
 }


### PR DESCRIPTION
https://denhaag.jira.com/browse/KP-587?atlOrigin=eyJpIjoiZjc1NDQ5M2NmZjZhNDhhYjk3ZWQ3ZmVkMWZmNjJiZmYiLCJwIjoiaiJ9

Je kunt in GZAC een textarea invullen met multiline. Deze wordt in het formulier aan de FE gerenderd als div (niet als textarea) met een class read only omdat de klant deze info niet mag aanpassen. Alleen de enters (\n) worden niet herkend door een normale div. 