### PR TITLE
Use param for keycloak redirect

### DIFF
--- a/packages/app/src/constants/routes.tsx
+++ b/packages/app/src/constants/routes.tsx
@@ -100,7 +100,14 @@ export const routes = [
     path: "/keycloak/callback",
     Component: () => {
       const [searchParams] = useSearchParams();
-      return <Navigate to={searchParams.get("redirect_url") || "/"} />;
+      const redirectUrl = searchParams.get("redirect_url");
+
+      try {
+        if (redirectUrl) new URL(redirectUrl);
+        return <Navigate to="/" />;
+      } catch {
+        return <Navigate to={redirectUrl ? redirectUrl : "/"} />;
+      }
     },
   },
   {

--- a/packages/app/src/constants/routes.tsx
+++ b/packages/app/src/constants/routes.tsx
@@ -12,7 +12,7 @@ import {
 } from "@nl-portal/nl-portal-user-interface";
 import { paths } from "./paths";
 import { config } from "./config";
-import { Navigate } from "react-router-dom";
+import { Navigate, useSearchParams } from "react-router-dom";
 import ThemeSampleOverviewPage from "../pages/ThemeSampleOverviewPage";
 import ThemeSampleListPage from "../pages/ThemeSampleListPage";
 import ThemeSampleDetailPage from "../pages/ThemeSampleDetailPage";
@@ -98,7 +98,10 @@ export const routes = [
   },
   {
     path: "/keycloak/callback",
-    element: <Navigate to={sessionStorage.getItem("entryUrl") || "/"} />,
+    Component: () => {
+      const [searchParams] = useSearchParams();
+      return <Navigate to={searchParams.get("redirect_url") || "/"} />;
+    },
   },
   {
     path: paths.noMatch,

--- a/packages/user-interface/src/components/Layout.tsx
+++ b/packages/user-interface/src/components/Layout.tsx
@@ -73,9 +73,8 @@ const LayoutComponent: FC<LayoutComponentProps> = ({
       <ResponsiveContent className="denhaag-page-content denhaag-responsive-content--sidebar">
         <Menu items={navigationItems} legacy={legacy} />
         <main className="denhaag-page-content__main">
-          <PageMetaData navigationItems={navigationItems}>
-            {<Outlet context={{ paths }} />}
-          </PageMetaData>
+          <PageMetaData navigationItems={navigationItems} />
+          {<Outlet context={{ paths }} />}
         </main>
       </ResponsiveContent>
       {online && (

--- a/packages/user-interface/src/components/PageMetaData.tsx
+++ b/packages/user-interface/src/components/PageMetaData.tsx
@@ -1,20 +1,18 @@
-import { ReactElement, useEffect } from "react";
+import { useEffect } from "react";
 import { useIntl } from "react-intl";
 import { NavigationItem } from "../interfaces/navigation-item";
 import { useMatches } from "react-router-dom";
 import { getCurrentNavigationPage } from "../utils/get-current-navigation-page";
 
 interface PageMetaDataProps {
-  children: ReactElement;
   navigationItems: NavigationItem[][];
 }
 
-const PageMetaData = ({ children, navigationItems }: PageMetaDataProps) => {
+const PageMetaData = ({ navigationItems }: PageMetaDataProps) => {
   const intl = useIntl();
   const matches = useMatches();
   const currentPage =
     getCurrentNavigationPage(matches, navigationItems) || navigationItems[0][0];
-
   const pageTitle = intl.formatMessage({
     id: `pageTitles.${currentPage?.titleTranslationKey}`,
   });
@@ -22,18 +20,12 @@ const PageMetaData = ({ children, navigationItems }: PageMetaDataProps) => {
   const documentTitle = currentPage?.titleTranslationKey
     ? `${pageTitle} - ${appName}`
     : appName;
-  const ENTRY_URL_KEY = "entryUrl";
-  const entryUrl = sessionStorage.getItem(ENTRY_URL_KEY);
-
-  if (entryUrl) {
-    sessionStorage.removeItem(ENTRY_URL_KEY);
-  }
 
   useEffect(() => {
     document.title = documentTitle;
   }, [documentTitle]);
 
-  return children;
+  return null;
 };
 
 export default PageMetaData;

--- a/packages/user-interface/src/tests/components/PageMetaData.test.tsx
+++ b/packages/user-interface/src/tests/components/PageMetaData.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import { MockWrapper } from "@nl-portal/nl-portal-localization";
-import Page from "../../components/PageMetaData";
+import PageMetaData from "../../components/PageMetaData";
 import { NavigationItem } from "../../interfaces/navigation-item";
 import { Outlet, RouterProvider, createBrowserRouter } from "react-router-dom";
 import { testPaths as paths } from "../../providers/TestProvider";
@@ -20,11 +20,7 @@ const navigationItems: NavigationItem[][] = [
 
 const route = {
   path: paths.overview,
-  element: (
-    <Page navigationItems={navigationItems}>
-      <span>test</span>
-    </Page>
-  ),
+  element: <PageMetaData navigationItems={navigationItems} />,
 };
 
 const router = createBrowserRouter([


### PR DESCRIPTION
- Oude methode met de entryUrl verwijderd
- Geef path waarop geland moet worden mee in een param en verwerk die bij het landen op de /keycloak/callback url
- Keycloak init in een ref geplaatst om multiple instanties te voorkomen