### PR TITLE
feat: support path interpolation of informatieobjecttype for portalFileUpload

### DIFF
--- a/packages/user-interface/src/components/FileUpload.tsx
+++ b/packages/user-interface/src/components/FileUpload.tsx
@@ -10,7 +10,7 @@ export interface UploadedFile {
 }
 
 interface FileUploadProps {
-  context?: object;
+  context: object;
   disabled: boolean;
   multiple: boolean;
   onChange: (fileList: Array<UploadedFile>) => void;

--- a/packages/user-interface/src/components/FileUpload.tsx
+++ b/packages/user-interface/src/components/FileUpload.tsx
@@ -26,7 +26,7 @@ const FileUpload: FC<FileUploadProps> = ({
 }) => {
   const [isLoading, setLoading] = useState(false);
   const [fileList, setFileList] = useState<Array<UploadedFile>>([]);
-  const [dataContext, setDataContext] = useState<object | undefined>(undefined);
+  const [dataContext, setDataContext] = useState(context);
 
   const uploadFile = (file: File) => {
     const keycloakToken = TOKEN_OBJECT[TOKEN_KEY];

--- a/packages/user-interface/src/components/FileUpload.tsx
+++ b/packages/user-interface/src/components/FileUpload.tsx
@@ -10,7 +10,7 @@ export interface UploadedFile {
 }
 
 interface FileUploadProps {
-  context?: object | undefined;
+  context?: object;
   disabled: boolean;
   multiple: boolean;
   onChange: (fileList: Array<UploadedFile>) => void;

--- a/packages/user-interface/src/components/FormIoUploader.tsx
+++ b/packages/user-interface/src/components/FormIoUploader.tsx
@@ -6,6 +6,7 @@ import { Root, createRoot } from "react-dom/client";
 class FormIoUploader extends ReactComponent {
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   private component: any;
+  private data: object | undefined;
   private element: Root | null;
 
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,6 +14,7 @@ class FormIoUploader extends ReactComponent {
     super(component, options, data);
     this.component = component;
     this.element = null;
+    this.data = data;
 
     if (this.component.multipleFiles === undefined) {
       this.component.multipleFiles = true;
@@ -54,12 +56,14 @@ class FormIoUploader extends ReactComponent {
       files.map((file) => file.url),
       undefined,
     );
+    this.render();
   };
 
   attachReact = (element: Element) => {
     this.element = createRoot(element);
     this.element.render(
       <FileUpload
+        context={this.data}
         disabled={this.component.disabled}
         multiple={this.component.multipleFiles}
         onChange={this.onChangeHandler}

--- a/packages/user-interface/src/components/FormIoUploader.tsx
+++ b/packages/user-interface/src/components/FormIoUploader.tsx
@@ -6,7 +6,7 @@ import { Root, createRoot } from "react-dom/client";
 class FormIoUploader extends ReactComponent {
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   private component: any;
-  private data: object | undefined;
+  private data: object;
   private element: Root | null;
 
   //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/user-interface/src/components/FormIoUploader.tsx
+++ b/packages/user-interface/src/components/FormIoUploader.tsx
@@ -56,7 +56,6 @@ class FormIoUploader extends ReactComponent {
       files.map((file) => file.url),
       undefined,
     );
-    this.render();
   };
 
   attachReact = (element: Element) => {


### PR DESCRIPTION
This adds the ability to use interpolation for the `informatieobjecttype` property of a portalFileUpload formio component. This makes it possible to submit informatieobjecten of variable type by setting the type in the form data. This interpolation is limited to the context of the portalFileUpload component where the interpolation is used.