### PR TITLE
feat: dont run ci on lerna commit

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -63,7 +63,7 @@ jobs:
     detect-variables:
         runs-on: ubuntu-latest
         outputs:
-            version: ${{ steps.detect-scope.outputs.SCOPE == 'SNAPSHOT' && steps.generate-snapshot-version.outputs.VERSION || steps.get-project-version.outputs.PROJECT_VERSION }}
+            version: ${{ steps.generate-snapshot-version.outputs.VERSION }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
                     GIT_COMMITTER_NAME: "nl-portal"
                 run: |
                     git push --set-upstream origin HEAD
-                    lerna version ${{ env.ARTIFACT_VERSION }} --no-changelog --no-private --no-commit-hooks --yes
+                    lerna version ${{ env.ARTIFACT_VERSION }} --no-changelog --no-private --no-commit-hooks --message 'chore: released %s [skip ci]' --yes
             -   name: lerna publish
                 env:
                     NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "publish": "lerna publish from-package",
-    "release": "lerna version 1.6.0 --no-changelog --no-private --no-commit-hooks",
+    "release": "lerna version 1.6.0 --no-changelog --no-private --no-commit-hooks --message 'chore: released %s [skip ci]'",
     "test": "pnpm run --recursive --parallel test",
     "typecheck": "pnpm run --recursive --parallel typecheck",
     "postinstall": "husky"


### PR DESCRIPTION
* skips unnecessary ci after new version has been published
* fixes snapshot version not being used for snapshot