### PR TITLE
fix: moved auth modal labels from custom-messages (app) to messages (localization)

### DIFF
--- a/packages/app/src/i18n/custom-messages/en-gb.ts
+++ b/packages/app/src/i18n/custom-messages/en-gb.ts
@@ -4,12 +4,6 @@ export const EN_GB_MESSAGES: Messages = {
   [DEFAULT_LOCALES.ENGLISH]: {
     "app.appName": "MijnDenHaag",
     "pageTitles.sample": "Theme sample",
-    "auth.inactive.title": "Do you want to stay logged in?",
-    "auth.inactive.text":
-      "You have been inactive for 10 minutes. You will soon be automatically logged out of the secure environment. If you have entered any data, it will be lost. Click 'Stay logged in' to continue or 'Log out' to stop.",
-    "auth.inactive.close": "Close",
-    "auth.inactive.logout": "Log out",
-    "auth.inactive.stayLoggedIn": "Stay logged in",
     "case.bezwaar-behandelen.title": "Notice of objection",
     "case.bezwaar-behandelen.status.intake-afgerond": "Intake completed",
     "case.bezwaar-behandelen.status.indieningsvereisten-getoetst":

--- a/packages/app/src/i18n/custom-messages/nl-nl.ts
+++ b/packages/app/src/i18n/custom-messages/nl-nl.ts
@@ -4,12 +4,6 @@ export const NL_NL_MESSAGES: Messages = {
   [DEFAULT_LOCALES.DUTCH]: {
     "app.appName": "MijnDenHaag",
     "pageTitles.sample": "Thema voorbeeld",
-    "auth.inactive.title": "Wilt u ingelogd blijven?",
-    "auth.inactive.text":
-      "U heeft 10 minuten niets gedaan. U wordt binnenkort automatisch uitgelogd uit de beveiligde omgeving. Als u gegevens heeft ingevuld, dan gaan deze verloren. Klik op 'Ingelogd blijven' om verder te gaan of op 'Uitloggen' om te stoppen.",
-    "auth.inactive.close": "Sluiten",
-    "auth.inactive.logout": "Uitloggen",
-    "auth.inactive.stayLoggedIn": "Ingelogd blijven",
     "case.bezwaar-behandelen.title": "Bezwaarschrift",
     "case.bezwaar-behandelen.status.intake-afgerond": "Intake afgerond",
     "case.bezwaar-behandelen.status.indieningsvereisten-getoetst":

--- a/packages/localization/src/i18n/messages/en-gb.ts
+++ b/packages/localization/src/i18n/messages/en-gb.ts
@@ -156,5 +156,11 @@ export const EN_GB_MESSAGES: Messages = {
     "searchForm.messages.searchButton": "Search",
     "searchForm.messages.totalElements": "{total} messages",
     "searchForm.messages.totalElements.singular": "{total} message",
+    "auth.inactive.title": "Do you want to stay logged in?",
+    "auth.inactive.text":
+      "You have been inactive for 10 minutes. You will soon be automatically logged out of the secure environment. If you have entered any data, it will be lost. Click 'Stay logged in' to continue or 'Log out' to stop.",
+    "auth.inactive.close": "Close",
+    "auth.inactive.logout": "Log out",
+    "auth.inactive.stayLoggedIn": "Stay logged in",
   },
 };

--- a/packages/localization/src/i18n/messages/nl-nl.ts
+++ b/packages/localization/src/i18n/messages/nl-nl.ts
@@ -163,5 +163,11 @@ export const NL_NL_MESSAGES: Messages = {
     "searchForm.messages.searchButton": "Zoeken",
     "searchForm.messages.totalElements": "{total} berichten",
     "searchForm.messages.totalElements.singular": "{total} bericht",
+    "auth.inactive.title": "Wilt u ingelogd blijven?",
+    "auth.inactive.text":
+      "U heeft 10 minuten niets gedaan. U wordt binnenkort automatisch uitgelogd uit de beveiligde omgeving. Als u gegevens heeft ingevuld, dan gaan deze verloren. Klik op 'Ingelogd blijven' om verder te gaan of op 'Uitloggen' om te stoppen.",
+    "auth.inactive.close": "Sluiten",
+    "auth.inactive.logout": "Uitloggen",
+    "auth.inactive.stayLoggedIn": "Ingelogd blijven",
   },
 };


### PR DESCRIPTION
I've tested the refactored auth package with the Den Haag implementation on my local environment, and i've found one minor issues with the labels. 