### PR TITLE
Feature/fix address issue

### DIFF
--- a/packages/user-interface/src/tests/utils/person-data.test.tsx
+++ b/packages/user-interface/src/tests/utils/person-data.test.tsx
@@ -65,6 +65,11 @@ describe("getStreetString", () => {
     expect(streetString).toBe("Kerkweg 1A");
   });
 
+  it("should return street name, number and addition when only street, number and addition inputs are valid", () => {
+    const streetString = getStreetString("Kerkweg", "1", null, "20");
+    expect(streetString).toBe("Kerkweg 1 20");
+  });
+
   it("should return street name, number, letter and addition when all inputs are valid", () => {
     const streetString = getStreetString("Kerkweg", "1", "A", "Bis");
     expect(streetString).toBe("Kerkweg 1A Bis");

--- a/packages/user-interface/src/utils/person-data.tsx
+++ b/packages/user-interface/src/utils/person-data.tsx
@@ -19,25 +19,13 @@ const getNationalitiesString = (
 };
 
 const getStreetString = (
-  street: string | null | undefined,
-  number: string | null | undefined,
-  letter: string | null | undefined,
-  addition: string | null | undefined,
+  street?: string | null,
+  number?: string | null,
+  letter?: string | null,
+  addition?: string | null,
 ): string => {
-  if (street && number && letter && addition) {
-    return `${street} ${number}${letter} ${addition}`;
-  }
-  if (street && number && letter) {
-    return `${street} ${number}${letter}`;
-  }
-  if (street && number) {
-    return `${street} ${number}`;
-  }
-  if (street) {
-    return street;
-  }
-
-  return "";
+  const houseNr = number ? `${number}${letter ?? ""}` : null;
+  return [street, houseNr, addition].filter(Boolean).join(" ");
 };
 
 const getPostalCodeCityString = (


### PR DESCRIPTION
Show housenummer addition also when the letter is empty. For example `Kerkweg 1 20` is also a valid address.