### PR TITLE
fix: crash when geboortedatum  is undefined

### DIFF
--- a/packages/user-interface/src/pages/AccountPage.tsx
+++ b/packages/user-interface/src/pages/AccountPage.tsx
@@ -290,7 +290,7 @@ const AccountPage = ({
               title: <FormattedMessage id="account.detail.dateOfBirth" />,
               detail: (
                 <DescriptionListDetail data-testid="persoonsgegevens-birthdate">
-                  {persoon?.geboorte?.datum
+                  {persoon?.geboorte?.datum?.datum
                     ? formatDate({
                         date: persoon?.geboorte?.datum.datum,
                       })

--- a/packages/user-interface/src/pages/AccountPage.tsx
+++ b/packages/user-interface/src/pages/AccountPage.tsx
@@ -292,7 +292,7 @@ const AccountPage = ({
                 <DescriptionListDetail data-testid="persoonsgegevens-birthdate">
                   {persoon?.geboorte?.datum?.datum
                     ? formatDate({
-                        date: persoon?.geboorte?.datum.datum,
+                        date: persoon.geboorte.datum.datum,
                       })
                     : ""}
                 </DescriptionListDetail>


### PR DESCRIPTION
Fix a crash when `persoon?.geboorte?.datum?.datum` is undefined.