### PR TITLE
Use 'omschrijving' as default and fix related issues

### DIFF
--- a/packages/api/codegen.yml
+++ b/packages/api/codegen.yml
@@ -1,6 +1,6 @@
 overwrite: true
 noSilentErrors: true
-schema: "http://localhost:8090/graphql"
+schema: "http://localhost:8080/graphql"
 documents: "./src/{fragments,mutations,queries}/**/*.{ts,tsx}"
 generates:
   src/generated/Graphql.tsx:

--- a/packages/api/src/generated/Graphql.tsx
+++ b/packages/api/src/generated/Graphql.tsx
@@ -16,25 +16,28 @@ export type Scalars = {
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
   Date: { input: any; output: any; }
+  DateTime: { input: any; output: any; }
   JSON: { input: any; output: any; }
-  LocalDateTime: { input: any; output: any; }
+  LocalTime: { input: any; output: any; }
+  Locale: { input: any; output: any; }
+  PositiveFloat: { input: any; output: any; }
   UUID: { input: any; output: any; }
   ZonedDateTime: { input: any; output: any; }
 };
 
 export type ActiesPage = {
   __typename?: 'ActiesPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductActie>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -57,14 +60,14 @@ export type Bericht = {
   berichtType: BerichtType;
   bijlages: Array<Scalars['String']['output']>;
   documenten: Array<Document>;
-  einddatumHandelingstermijn: Scalars['LocalDateTime']['output'];
+  einddatumHandelingstermijn: Scalars['ZonedDateTime']['output'];
   geopend: Scalars['Boolean']['output'];
   handelingsperspectief: BerichtHandelingsperspectief;
   id?: Maybe<Scalars['UUID']['output']>;
   identificatie: BerichtIdentificatie;
   onderwerp: Scalars['String']['output'];
-  publicatiedatum: Scalars['LocalDateTime']['output'];
-  referentie?: Maybe<Scalars['String']['output']>;
+  publicatiedatum: Scalars['ZonedDateTime']['output'];
+  referentie: Scalars['String']['output'];
 };
 
 export enum BerichtHandelingsperspectief {
@@ -88,17 +91,17 @@ export enum BerichtType {
 
 export type BerichtenPage = {
   __typename?: 'BerichtenPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<Bericht>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -125,7 +128,7 @@ export type Besluit = {
 
 export type BesluitAuditTrail = {
   __typename?: 'BesluitAuditTrail';
-  aanmaakdatum?: Maybe<Scalars['LocalDateTime']['output']>;
+  aanmaakdatum?: Maybe<Scalars['ZonedDateTime']['output']>;
   actie: Scalars['String']['output'];
   actieWeergave?: Maybe<Scalars['String']['output']>;
   applicatieId?: Maybe<Scalars['String']['output']>;
@@ -158,17 +161,17 @@ export type BesluitDocument = {
 
 export type BesluitPage = {
   __typename?: 'BesluitPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<Besluit>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -188,17 +191,17 @@ export type BesluitType = {
 
 export type BestandenPage = {
   __typename?: 'BestandenPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductBestand>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -615,17 +618,17 @@ export type CategorieRelatieForeignKey = {
 
 export type ContactenPage = {
   __typename?: 'ContactenPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductContact>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -682,7 +685,7 @@ export enum DigitaleAdresType {
 }
 
 export type DirectPaymentRequestInput = {
-  amount: Scalars['Float']['input'];
+  amount: Scalars['PositiveFloat']['input'];
   identifier: Scalars['String']['input'];
   langId?: InputMaybe<Scalars['String']['input']>;
   orderId: Scalars['String']['input'];
@@ -697,7 +700,7 @@ export type DirectPaymentResponse = {
 
 export type DirectPaymentStatus = {
   __typename?: 'DirectPaymentStatus';
-  status: DirectPaymentStatusCategory;
+  status?: Maybe<DirectPaymentStatusCategory>;
 };
 
 export enum DirectPaymentStatusCategory {
@@ -784,7 +787,7 @@ export type HandelsNaam = {
 
 export type Hoofdvestiging = {
   __typename?: 'Hoofdvestiging';
-  adressen?: Maybe<Array<Adres>>;
+  adressen?: Maybe<Array<Maybe<Adres>>>;
   eersteHandelsnaam: Scalars['String']['output'];
   indCommercieleVestiging: Scalars['String']['output'];
   indHoofdvestiging: Scalars['String']['output'];
@@ -795,33 +798,33 @@ export type Hoofdvestiging = {
 
 export type LinksPage = {
   __typename?: 'LinksPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductLink>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
 export type LocatiesPage = {
   __typename?: 'LocatiesPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductLocatie>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -829,13 +832,13 @@ export type MaatschappelijkeActiviteit = {
   __typename?: 'MaatschappelijkeActiviteit';
   embedded?: Maybe<Embedded>;
   formeleRegistratiedatum?: Maybe<Scalars['String']['output']>;
-  handelsnamen?: Maybe<Array<HandelsNaam>>;
+  handelsnamen?: Maybe<Array<Maybe<HandelsNaam>>>;
   indNonMailing?: Maybe<Scalars['String']['output']>;
   kvkNummer: Scalars['String']['output'];
   materieleRegistratie?: Maybe<MaterieleRegistratie>;
   naam: Scalars['String']['output'];
-  sbiActiviteiten?: Maybe<Array<SbiActiviteit>>;
-  statutaireNaam?: Maybe<Scalars['String']['output']>;
+  sbiActiviteiten?: Maybe<Array<Maybe<SbiActiviteit>>>;
+  statutaireNaam: Scalars['String']['output'];
   totaalWerkzamePersonen?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -846,25 +849,25 @@ export type MaterieleRegistratie = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  /** Create DigitaleAdres for User */
+  /**  Create DigitaleAdres for User */
   createUserDigitaleAdres?: Maybe<DigitaleAdresResponse>;
-  /** Create Partij for user */
+  /**  Create Partij for user */
   createUserPartij?: Maybe<PartijResponse>;
-  /** Delete DigitaleAdres of User by Id */
+  /**  Delete DigitaleAdres of User by Id */
   deleteUserDigitaleAdres?: Maybe<Scalars['Boolean']['output']>;
-  /** Do Worldline Direct payment */
+  /**  Do Worldline Direct payment */
   doDirectPayment: DirectPaymentResponse;
-  /** Create Ogone payment with hash and fields */
+  /**  Create Ogone payment with hash and fields */
   generateOgonePayment: OgonePayment;
-  /** Submit a task */
+  /**  Submit a task */
   submitTaakV2: TaakV2;
-  /** Update product */
+  /**  Update product */
   updateProduct?: Maybe<OpenProductProduct>;
-  /** Update product verbruiks object */
+  /**  Update product verbruiks object */
   updateProductVerbruiksObject: ProductVerbruiksObject;
-  /** Update DigitaleAdres of User */
+  /**  Update DigitaleAdres of User */
   updateUserDigitaleAdres?: Maybe<DigitaleAdresResponse>;
-  /** Update user Partij */
+  /**  Update user Partij */
   updateUserPartij?: Maybe<PartijResponse>;
 };
 
@@ -922,7 +925,7 @@ export type MutationUpdateUserPartijArgs = {
 
 export type OgoneBetaling = {
   __typename?: 'OgoneBetaling';
-  bedrag: Scalars['Float']['output'];
+  bedrag: Scalars['PositiveFloat']['output'];
   betaalkenmerk: Scalars['String']['output'];
   pspid: Scalars['String']['output'];
 };
@@ -934,7 +937,7 @@ export type OgonePayment = {
 };
 
 export type OgonePaymentRequestInput = {
-  amount: Scalars['Float']['input'];
+  amount: Scalars['PositiveFloat']['input'];
   failureUrl?: InputMaybe<Scalars['String']['input']>;
   langId?: InputMaybe<Scalars['String']['input']>;
   orderId: Scalars['String']['input'];
@@ -1406,7 +1409,7 @@ export enum OpenKlant2Landcode {
   Zwitserland = 'ZWITSERLAND'
 }
 
-/** A Type that represents a Klantinteracties API Partij object */
+/**  A Type that represents a Klantinteracties API Partij object */
 export type OpenKlant2Partij = {
   __typename?: 'OpenKlant2Partij';
   betrokkenen?: Maybe<Array<OpenKlant2ForeignKey>>;
@@ -1528,7 +1531,7 @@ export type OpenProductPrijs = {
 
 export type OpenProductPrijsOptie = {
   __typename?: 'OpenProductPrijsOptie';
-  bedrag: Scalars['Float']['output'];
+  bedrag: Scalars['PositiveFloat']['output'];
   beschrijving: Scalars['String']['output'];
   uuid: Scalars['UUID']['output'];
 };
@@ -1656,7 +1659,7 @@ export type OpenProductThema = {
   aanmaakDatum: Scalars['ZonedDateTime']['output'];
   beschrijving?: Maybe<Scalars['String']['output']>;
   gepubliceerd?: Maybe<Scalars['Boolean']['output']>;
-  /** UUID of the hoofdthema, which this thema is related to. */
+  /**  UUID of the hoofdthema, which this thema is related to. */
   hoofdThema?: Maybe<Scalars['UUID']['output']>;
   naam: Scalars['String']['output'];
   producten?: Maybe<Array<OpenProductProduct>>;
@@ -1711,17 +1714,17 @@ export type OrganisatieIdentificatieInput = {
 
 export type OrganisatiesPage = {
   __typename?: 'OrganisatiesPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductOrganisatie>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -1788,17 +1791,17 @@ export type PrefillResponse = {
 
 export type PrijzenPage = {
   __typename?: 'PrijzenPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductPrijs>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -1806,8 +1809,8 @@ export type Product = {
   __typename?: 'Product';
   documenten: Array<Scalars['String']['output']>;
   eigenschappen?: Maybe<Scalars['JSON']['output']>;
-  geldigTot?: Maybe<Scalars['LocalDateTime']['output']>;
-  geldigVan: Scalars['LocalDateTime']['output'];
+  geldigTot?: Maybe<Scalars['DateTime']['output']>;
+  geldigVan: Scalars['DateTime']['output'];
   id?: Maybe<Scalars['UUID']['output']>;
   naam: Scalars['String']['output'];
   parameters?: Maybe<Scalars['JSON']['output']>;
@@ -1829,30 +1832,30 @@ export type ProductDetails = {
 
 export type ProductPage = {
   __typename?: 'ProductPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<Product>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
 export type ProductType = {
   __typename?: 'ProductType';
-  /** Get list of available beslistabellen, with their object configurations */
+  /**  Get list of available beslistabellen, with their object configurations */
   beslistabelMappings?: Maybe<Array<Scalars['String']['output']>>;
   eigenschappen?: Maybe<Scalars['JSON']['output']>;
   id?: Maybe<Scalars['UUID']['output']>;
   naam: Scalars['String']['output'];
   omschrijving?: Maybe<Scalars['String']['output']>;
   parameters?: Maybe<Scalars['JSON']['output']>;
-  /** Get list of available forms to prefill, with their object configurations */
+  /**  Get list of available forms to prefill, with their object configurations */
   prefillMappings?: Maybe<Scalars['JSON']['output']>;
   productSubType?: Maybe<Scalars['String']['output']>;
   zaaktypen: Array<Scalars['UUID']['output']>;
@@ -1860,17 +1863,17 @@ export type ProductType = {
 
 export type ProductTypesPage = {
   __typename?: 'ProductTypesPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductProductType>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -1884,219 +1887,146 @@ export type ProductVerbruiksObject = {
 
 export type ProductenPage = {
   __typename?: 'ProductenPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductProduct>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
 export type Query = {
   __typename?: 'Query';
-  /**
-   * find all form definitions from repository
-   * @deprecated This method is not used by the NL Portal frontend and is not being replaced.
-   */
-  allFormDefinitions: Array<FormDefinition>;
-  /** Find the Partij of the authenticated user. */
+  /**  Find the Partij of the authenticated user. */
   findUserPartij?: Maybe<OpenKlant2Partij>;
-  /** Gets the bedrijf data */
+  /**  Gets the bedrijf data */
   getBedrijf?: Maybe<MaatschappelijkeActiviteit>;
-  /** Gets a single Bericht by Id */
+  /**  Gets a single Bericht by Id */
   getBericht?: Maybe<Bericht>;
-  /**
-   *
-   *         Returns a paginated list of all Berichten
-   *         Could partial search on 'onderwerp'
-   *
-   */
   getBerichten: BerichtenPage;
-  /** Get all besluit by id */
+  /**  Get all besluit by id */
   getBesluit: Besluit;
-  /** Get all besluit audit trails by id */
+  /**  Get all besluit audit trails by id */
   getBesluitAuditTrail: BesluitAuditTrail;
-  /** Get all besluit audit trails */
+  /**  Get all besluit audit trails */
   getBesluitAuditTrails: Array<BesluitAuditTrail>;
-  /** Get all besluit document by id */
+  /**  Get all besluit document by id */
   getBesluitDocument: BesluitDocument;
-  /** Get all besluit documents */
+  /**  Get all besluit documents */
   getBesluitDocumenten: Array<BesluitDocument>;
-  /** Get all besluiten */
+  /**  Get all besluiten */
   getBesluiten: BesluitPage;
-  /** Gets the number of people living in the same house of the adresseerbaarObjectIdentificatie */
+  /**  Gets the number of people living in the same house of the adresseerbaarObjectIdentificatie */
   getBewonersAantalV2?: Maybe<Scalars['Int']['output']>;
-  /**
-   *
-   *         Get Decision by key and json as source
-   *         Don't use it directly but via custom queries
-   *
-   */
   getDecision: Array<Scalars['JSON']['output']>;
   getDirectPaymentStatus: DirectPaymentStatus;
-  /** Gets a document content by id as base64 encoded */
+  /**  Gets a document content by id as base64 encoded */
   getDocumentContent: DocumentContent;
   /**
-   * find single form definition from repository or Objecten API
-   * @deprecated Replaced by getFormDefinitionByName and getFormDefinitionByObjectenApiUrl, replace with getFormDefinitionByName or getFormDefinitionByObjectenApiUrl
+   *  find single form definition from repository or Objecten API
+   * deprecated(
+   *  reason: "Replaced by getFormDefinitionByName and getFormDefinitionByObjectenApiUrl, replace with getFormDefinitionByName or getFormDefinitionByObjectenApiUrl"
+   * )
    */
   getFormDefinitionById?: Maybe<FormDefinition>;
-  /** find single form definition from repository */
+  /**  find single form definition from repository */
   getFormDefinitionByName?: Maybe<FormDefinition>;
-  /** find single form definition from the Objecten API */
+  /**  find single form definition from the Objecten API */
   getFormDefinitionByObjectenApiUrl?: Maybe<FormDefinition>;
-  /** Gets the data of the gemachtigde */
-  getGemachtigdeV2: GemachtigdeV2;
-  /** Get a Open product type by id */
+  /**  Gets the data of the gemachtigde */
+  getGemachtigdeV2?: Maybe<GemachtigdeV2>;
+  /**  Get a Open product type by id */
   getOpenProduct?: Maybe<OpenProductProduct>;
-  /** Get a actie */
+  /**  Get a actie */
   getOpenProductActie?: Maybe<OpenProductActie>;
-  /** Get decision by actie naam */
+  /**  Get decision by actie naam */
   getOpenProductActieDecision: Array<Scalars['JSON']['output']>;
-  /** Get all acties */
+  /**  Get all acties */
   getOpenProductActies: ActiesPage;
-  /** Get a bestand */
+  /**  Get a bestand */
   getOpenProductBestand?: Maybe<OpenProductBestand>;
-  /** Get all bestanden */
+  /**  Get all bestanden */
   getOpenProductBestanden: BestandenPage;
-  /** Get a contact */
+  /**  Get a contact */
   getOpenProductContact?: Maybe<OpenProductContact>;
-  /** Get all contacten */
+  /**  Get all contacten */
   getOpenProductContacten: ContactenPage;
-  /** Get all hoofd themas */
+  /**  Get all hoofd themas */
   getOpenProductHoofdThemas: Array<OpenProductThema>;
-  /** Get all hoofd themas by producten */
+  /**  Get all hoofd themas by producten */
   getOpenProductHoofdThemasByProducten: Array<OpenProductThema>;
-  /** Get a link */
+  /**  Get a link */
   getOpenProductLink?: Maybe<OpenProductLink>;
-  /** Get all links */
+  /**  Get all links */
   getOpenProductLinks: LinksPage;
-  /** Get a locatie */
+  /**  Get a locatie */
   getOpenProductLocatie?: Maybe<OpenProductLocatie>;
-  /** Get all locaties */
+  /**  Get all locaties */
   getOpenProductLocaties: LocatiesPage;
-  /** Get a organisatie */
+  /**  Get a organisatie */
   getOpenProductOrganisatie?: Maybe<OpenProductOrganisatie>;
-  /** Get all organisaties */
+  /**  Get all organisaties */
   getOpenProductOrganisaties: OrganisatiesPage;
-  /** Get a prijs */
+  /**  Get a prijs */
   getOpenProductPrijs?: Maybe<OpenProductPrijs>;
-  /** Get all prijzen */
+  /**  Get all prijzen */
   getOpenProductPrijzen: PrijzenPage;
-  /** Get a thema */
+  /**  Get a thema */
   getOpenProductThema?: Maybe<OpenProductThema>;
-  /** Get thema hierarchy */
+  /**  Get thema hierarchy */
   getOpenProductThemaHierarchy: Array<OpenProductThemaHierarchy>;
-  /** Get taken of a thema, including their parent themas */
+  /**  Get taken of a thema, including their parent themas */
   getOpenProductThemaTaken: Array<TaakV2>;
-  /** Get zaken of a thema, including their parent themas */
+  /**  Get zaken of a thema, including their parent themas */
   getOpenProductThemaZaken: Array<Zaak>;
-  /** Get all themas */
+  /**  Get all themas */
   getOpenProductThemas: ThemasPage;
-  /** Get all themas hierarchy */
+  /**  Get all themas hierarchy */
   getOpenProductThemasHierarchy: Array<OpenProductThemaHierarchy>;
-  /** Get a Open product type by id */
+  /**  Get a Open product type by id */
   getOpenProductType?: Maybe<OpenProductProductType>;
-  /** Get all Open product types  */
+  /**  Get all Open product types */
   getOpenProductTypes: ProductTypesPage;
-  /**
-   *
-   *         Get all Open producten
-   *         The allowed statussen:
-   *         - initieel
-   *         - gereed
-   *         - actief
-   *         - ingetrokken
-   *         - geweigerd
-   *         - verlopen
-   *
-   */
   getOpenProducten: ProductenPage;
-  /** Get a Open producten type by thema id */
+  /**  Get a Open producten type by thema id */
   getOpenProductenByThema: Array<OpenProductProduct>;
-  /** Gets the persoon data */
+  /**  Gets the persoon data */
   getPersoonV2?: Maybe<BrpPersoon>;
-  /** Get product by id */
+  /**  Get product by id */
   getProduct?: Maybe<Product>;
-  /**
-   *
-   *         Get Product Decision by key. Don't use it till it is configured in ProductType
-   *
-   */
   getProductDecision: Array<Scalars['JSON']['output']>;
-  /** Get list of taken by product name  */
+  /**  Get list of taken by product name */
   getProductTaken: Array<TaakV2>;
-  /** Get productType by name */
+  /**  Get productType by name */
   getProductType?: Maybe<ProductType>;
-  /** Get productTypes where the user has products */
+  /**  Get productTypes where the user has products */
   getProductTypes: Array<ProductType>;
-  /** Get list of verbruiksobjecten of product */
+  /**  Get list of verbruiksobjecten of product */
   getProductVerbruiksObjecten: Array<ProductVerbruiksObject>;
-  /**
-   *
-   *         Get list of zaken by product name or productTypeId
-   *         isOpen is optional, when not available, all zaken will be returned
-   *         isOpen is true, only zaken without enddate will be returned
-   *         isOpen is false, only zaken with an enddate will be returned
-   *
-   */
   getProductZaken: Array<Zaak>;
-  /**
-   *
-   *         Get list of products by product name or productTypeId
-   *         subProductType, is optional. It search for the subProductType in the products
-   *
-   */
   getProducten: ProductPage;
-  /** Get task by id V2 */
+  /**  Get task by id V2 */
   getTaakByIdV2?: Maybe<TaakV2>;
-  /** Get a list of tasks. Optional filter for zaak V2 */
+  /**  Get a list of tasks. Optional filter for zaak V2 */
   getTakenV2: TaakPageV2;
-  /** Returns the total amount of unopened Berichten */
+  /**  Returns the total amount of unopened Berichten */
   getUnopenedBerichtenCount: Scalars['Int']['output'];
-  /**
-   * Get DigitaleAdresen of authenticated user.
-   * @deprecated Use getUserDigitaleAdressen instead
-   */
-  getUserDigitaleAdresen?: Maybe<Array<DigitaleAdresResponse>>;
-  /** Get DigitaleAdressen of authenticated user. */
+  /**  Get DigitaleAdressen of authenticated user. */
   getUserDigitaleAdressen?: Maybe<Array<DigitaleAdresResponse>>;
-  /** Get KlantContact by id of authenticated user. */
+  /**  Get KlantContact by id of authenticated user. */
   getUserKlantContact?: Maybe<OpenKlant2Klantcontact>;
-  /**
-   *
-   *         Get KlantContacten of authenticated user and optional filter on .
-   *         identificatorType, like zaak or product
-   *         identificatorId, the uuid of the zaak or product
-   *
-   */
   getUserKlantContacten: Array<OpenKlant2Klantcontact>;
-  /** Get Partij by Id for authenticated user. */
+  /**  Get Partij by Id for authenticated user. */
   getUserPartij?: Maybe<OpenKlant2Partij>;
-  /** Gets a zaak by id */
+  /**  Gets a zaak by id */
   getZaak: Zaak;
-  /**
-   *
-   *         Gets all zaken for the user
-   *         isOpen is optional, when not available, all zaken will be returned
-   *         isOpen is true, only zaken without enddate will be returned
-   *         isOpen is false, only zaken with an enddate will be returned
-   *         omschrijving: partial search of this property. Since OpenZaak 1.18.0
-   *         identificatieContains: partial search of this property. Since OpenZaak 1.18.0
-   *
-   */
   getZaken: ZaakPage;
-  /**
-   *
-   *         Prefill data to start a form.
-   *
-   */
   productPrefill: PrefillResponse;
 };
 
@@ -2330,9 +2260,9 @@ export type QueryGetOpenProductenArgs = {
   pageNumber?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   productTypeCode?: InputMaybe<Scalars['String']['input']>;
-  productTypeCodes?: InputMaybe<Array<Scalars['String']['input']>>;
+  productTypeCodes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   productTypeId?: InputMaybe<Scalars['String']['input']>;
-  productTypeIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  productTypeIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   status?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2504,17 +2434,17 @@ export type TaakKoppeling = {
 
 export type TaakPageV2 = {
   __typename?: 'TaakPageV2';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<TaakV2>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -2549,22 +2479,22 @@ export type TaakV2 = {
   status: TaakStatus;
   titel: Scalars['String']['output'];
   url?: Maybe<TaakUrl>;
-  verloopdatum?: Maybe<Scalars['LocalDateTime']['output']>;
+  verloopdatum?: Maybe<Scalars['ZonedDateTime']['output']>;
 };
 
 export type ThemasPage = {
   __typename?: 'ThemasPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<OpenProductThema>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -2600,17 +2530,17 @@ export type ZaakDetails = {
 
 export type ZaakPage = {
   __typename?: 'ZaakPage';
-  /** The elements on this page */
+  /**  The elements on this page */
   content: Array<Zaak>;
-  /** The requested page number */
+  /**  The requested page number */
   number: Scalars['Int']['output'];
-  /** The number of elements on this page */
+  /**  The number of elements on this page */
   numberOfElements: Scalars['Int']['output'];
-  /** The requested page size */
+  /**  The requested page size */
   size: Scalars['Int']['output'];
-  /** The total number of elements */
+  /**  The total number of elements */
   totalElements: Scalars['Int']['output'];
-  /** The total number of available pages */
+  /**  The total number of available pages */
   totalPages: Scalars['Int']['output'];
 };
 
@@ -2680,7 +2610,7 @@ export type DeleteUserDigitaleAdresMutationVariables = Exact<{
 export type DeleteUserDigitaleAdresMutation = { __typename?: 'Mutation', deleteUserDigitaleAdres?: boolean | null };
 
 export type DoDirectPaymentMutationVariables = Exact<{
-  amount: Scalars['Float']['input'];
+  amount: Scalars['PositiveFloat']['input'];
   identifier: Scalars['String']['input'];
   langId?: InputMaybe<Scalars['String']['input']>;
   orderId: Scalars['String']['input'];
@@ -2692,7 +2622,7 @@ export type DoDirectPaymentMutationVariables = Exact<{
 export type DoDirectPaymentMutation = { __typename?: 'Mutation', doDirectPayment: { __typename?: 'DirectPaymentResponse', redirectUrl: string } };
 
 export type GenerateOgonePaymentMutationVariables = Exact<{
-  amount: Scalars['Float']['input'];
+  amount: Scalars['PositiveFloat']['input'];
   failureUrl?: InputMaybe<Scalars['String']['input']>;
   langId?: InputMaybe<Scalars['String']['input']>;
   orderId: Scalars['String']['input'];
@@ -2733,7 +2663,7 @@ export type GetBerichtQueryVariables = Exact<{
 }>;
 
 
-export type GetBerichtQuery = { __typename?: 'Query', getBericht?: { __typename?: 'Bericht', id?: any | null, berichtTekst: string, berichtType: BerichtType, einddatumHandelingstermijn: any, geopend: boolean, handelingsperspectief: BerichtHandelingsperspectief, onderwerp: string, publicatiedatum: any, referentie?: string | null, identificatie: { __typename?: 'BerichtIdentificatie', type: string, value: string }, documenten: Array<{ __typename?: 'Document', uuid: any, documentapi: string, identificatie?: string | null, creatiedatum?: string | null, titel?: string | null, formaat?: string | null, bestandsnaam?: string | null, bestandsomvang?: number | null }> } | null };
+export type GetBerichtQuery = { __typename?: 'Query', getBericht?: { __typename?: 'Bericht', id?: any | null, berichtTekst: string, berichtType: BerichtType, einddatumHandelingstermijn: any, geopend: boolean, handelingsperspectief: BerichtHandelingsperspectief, onderwerp: string, publicatiedatum: any, referentie: string, identificatie: { __typename?: 'BerichtIdentificatie', type: string, value: string }, documenten: Array<{ __typename?: 'Document', uuid: any, documentapi: string, identificatie?: string | null, creatiedatum?: string | null, titel?: string | null, formaat?: string | null, bestandsnaam?: string | null, bestandsomvang?: number | null }> } | null };
 
 export type GetBerichtenQueryVariables = Exact<{
   pageNumber?: InputMaybe<Scalars['Int']['input']>;
@@ -2752,7 +2682,7 @@ export type GetUnopenedBerichtenCountQuery = { __typename?: 'Query', getUnopened
 export type GetBedrijfQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetBedrijfQuery = { __typename?: 'Query', getBedrijf?: { __typename?: 'MaatschappelijkeActiviteit', naam: string, kvkNummer: string, embedded?: { __typename?: 'Embedded', eigenaar: { __typename?: 'Eigenaar', rechtsvorm: string }, hoofdvestiging: { __typename?: 'Hoofdvestiging', adressen?: Array<{ __typename?: 'Adres', straatnaam?: string | null, huisnummer?: number | null, postcode: string, plaats: string }> | null } } | null } | null };
+export type GetBedrijfQuery = { __typename?: 'Query', getBedrijf?: { __typename?: 'MaatschappelijkeActiviteit', naam: string, kvkNummer: string, embedded?: { __typename?: 'Embedded', eigenaar: { __typename?: 'Eigenaar', rechtsvorm: string }, hoofdvestiging: { __typename?: 'Hoofdvestiging', adressen?: Array<{ __typename?: 'Adres', straatnaam?: string | null, huisnummer?: number | null, postcode: string, plaats: string } | null> | null } } | null } | null };
 
 export type GetDirectPaymentStatusQueryVariables = Exact<{
   identifier: Scalars['String']['input'];
@@ -2760,7 +2690,7 @@ export type GetDirectPaymentStatusQueryVariables = Exact<{
 }>;
 
 
-export type GetDirectPaymentStatusQuery = { __typename?: 'Query', getDirectPaymentStatus: { __typename?: 'DirectPaymentStatus', status: DirectPaymentStatusCategory } };
+export type GetDirectPaymentStatusQuery = { __typename?: 'Query', getDirectPaymentStatus: { __typename?: 'DirectPaymentStatus', status?: DirectPaymentStatusCategory | null } };
 
 export type GetDocumentenQueryVariables = Exact<{
   id: Scalars['UUID']['input'];
@@ -2800,7 +2730,7 @@ export type GetPortaalFormulierByIdV2Query = { __typename?: 'Query', getTaakById
 export type GetGemachtigdeV2QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetGemachtigdeV2Query = { __typename?: 'Query', getGemachtigdeV2: { __typename?: 'GemachtigdeV2', persoon?: { __typename?: 'BrpPersoon', naam: { __typename?: 'BrpNaam', voornamen?: string | null, officialLastName?: string | null } } | null, bedrijf?: { __typename?: 'MaatschappelijkeActiviteit', naam: string } | null } };
+export type GetGemachtigdeV2Query = { __typename?: 'Query', getGemachtigdeV2?: { __typename?: 'GemachtigdeV2', persoon?: { __typename?: 'BrpPersoon', naam: { __typename?: 'BrpNaam', voornamen?: string | null, officialLastName?: string | null } } | null, bedrijf?: { __typename?: 'MaatschappelijkeActiviteit', naam: string } | null } | null };
 
 export type GetOpenProductenByThemaQueryVariables = Exact<{
   themaId: Scalars['UUID']['input'];
@@ -2836,7 +2766,7 @@ export type GetOpenProductQueryVariables = Exact<{
 }>;
 
 
-export type GetOpenProductQuery = { __typename?: 'Query', getOpenProduct?: { __typename?: 'OpenProductProduct', uuid: any, url?: string | null, naam: string, startDatum?: any | null, gepubliceerd?: boolean | null, aanmaakDatum: any, prijs?: number | null, status: OpenProductToegestaneStatus, frequentie: OpenProductFrequentie, verbruiksobject?: any | null, dataobject?: any | null, decisions: Array<any>, producttype: { __typename?: 'OpenProductProductProductType', code: string, uniformeProductNaam: string, toegestaneStatussen: Array<OpenProductToegestaneStatus> }, documenten: Array<{ __typename?: 'OpenProductUrl', url: string }>, zaken?: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean } } | null }> | null, taken?: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: number, betaalkenmerk: string, pspid: string } | null }> | null } | null };
+export type GetOpenProductQuery = { __typename?: 'Query', getOpenProduct?: { __typename?: 'OpenProductProduct', uuid: any, url?: string | null, naam: string, startDatum?: any | null, gepubliceerd?: boolean | null, aanmaakDatum: any, prijs?: number | null, status: OpenProductToegestaneStatus, frequentie: OpenProductFrequentie, verbruiksobject?: any | null, dataobject?: any | null, decisions: Array<any>, producttype: { __typename?: 'OpenProductProductProductType', code: string, uniformeProductNaam: string, toegestaneStatussen: Array<OpenProductToegestaneStatus> }, documenten: Array<{ __typename?: 'OpenProductUrl', url: string }>, zaken?: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean } } | null }> | null, taken?: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: any, betaalkenmerk: string, pspid: string } | null }> | null } | null };
 
 export type GetOpenProductenQueryVariables = Exact<{
   pageNumber?: InputMaybe<Scalars['Int']['input']>;
@@ -2885,7 +2815,7 @@ export type GetProductQueryVariables = Exact<{
 }>;
 
 
-export type GetProductQuery = { __typename?: 'Query', getProduct?: { __typename?: 'Product', id?: any | null, naam: string, status: string, geldigVan: any, geldigTot?: any | null, verbruiksobjecten: Array<{ __typename?: 'ProductVerbruiksObject', id?: any | null, soort?: string | null, data?: any | null }>, productDetails?: { __typename?: 'ProductDetails', id?: any | null, data: Array<any> } | null, zaken: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean } } | null }>, taken: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: number, betaalkenmerk: string, pspid: string } | null }> } | null };
+export type GetProductQuery = { __typename?: 'Query', getProduct?: { __typename?: 'Product', id?: any | null, naam: string, status: string, geldigVan: any, geldigTot?: any | null, verbruiksobjecten: Array<{ __typename?: 'ProductVerbruiksObject', id?: any | null, soort?: string | null, data?: any | null }>, productDetails?: { __typename?: 'ProductDetails', id?: any | null, data: Array<any> } | null, zaken: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean } } | null }>, taken: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: any, betaalkenmerk: string, pspid: string } | null }> } | null };
 
 export type GetProductenQueryVariables = Exact<{
   productName: Scalars['String']['input'];
@@ -2911,7 +2841,7 @@ export type GetTakenV2QueryVariables = Exact<{
 }>;
 
 
-export type GetTakenV2Query = { __typename?: 'Query', getTakenV2: { __typename?: 'TaakPageV2', totalElements: number, totalPages: number, content: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: number, betaalkenmerk: string, pspid: string } | null }> } };
+export type GetTakenV2Query = { __typename?: 'Query', getTakenV2: { __typename?: 'TaakPageV2', totalElements: number, totalPages: number, content: Array<{ __typename?: 'TaakV2', id: any, soort: TaakSoort, titel: string, status: TaakStatus, verloopdatum?: any | null, koppeling: { __typename?: 'TaakKoppeling', registratie: string, value?: string | null }, url?: { __typename?: 'TaakUrl', uri: string } | null, portaalformulier?: { __typename?: 'TaakForm', formulier: { __typename?: 'TaakFormulierV2', soort: string, value: string } } | null, ogonebetaling?: { __typename?: 'OgoneBetaling', bedrag: any, betaalkenmerk: string, pspid: string } | null }> } };
 
 export type GetUserDigitaleAdressenQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2931,7 +2861,7 @@ export type GetZaakQueryVariables = Exact<{
 }>;
 
 
-export type GetZaakQuery = { __typename?: 'Query', getZaak: { __typename?: 'Zaak', uuid: any, url: string, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string, omschrijvingGeneriek?: string | null }, status?: { __typename?: 'ZaakStatus', datumStatusGezet: string, statustype: { __typename?: 'ZaakStatusType', omschrijvingGeneriek?: string | null, isEindstatus: boolean }, substatussen: Array<{ __typename?: 'ZaakSubStatus', uuid: any, omschrijving: string, tijdstip: string }> } | null, statusGeschiedenis: Array<{ __typename?: 'ZaakStatus', datumStatusGezet: string, statustype: { __typename?: 'ZaakStatusType', omschrijvingGeneriek?: string | null, isEindstatus: boolean }, substatussen: Array<{ __typename?: 'ZaakSubStatus', uuid: any, omschrijving: string, tijdstip: string }> }>, statussen: Array<{ __typename?: 'StatusType', omschrijvingGeneriek?: string | null, omschrijving: string }>, documenten: Array<{ __typename?: 'Document', documentapi: string, bestandsnaam?: string | null, bestandsomvang?: number | null, creatiedatum?: string | null, formaat?: string | null, identificatie?: string | null, titel?: string | null, uuid: any }>, zaakdetails: { __typename?: 'ZaakDetails', data: Array<any>, zaak: string }, resultaat?: { __typename?: 'ZaakResultaat', toelichting?: string | null, resultaattype: { __typename?: 'ResultaatType', omschrijvingGeneriek?: string | null } } | null } };
+export type GetZaakQuery = { __typename?: 'Query', getZaak: { __typename?: 'Zaak', uuid: any, url: string, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string, omschrijving: string }, status?: { __typename?: 'ZaakStatus', datumStatusGezet: string, statustype: { __typename?: 'ZaakStatusType', omschrijving: string, isEindstatus: boolean }, substatussen: Array<{ __typename?: 'ZaakSubStatus', uuid: any, omschrijving: string, tijdstip: string }> } | null, statusGeschiedenis: Array<{ __typename?: 'ZaakStatus', datumStatusGezet: string, statustype: { __typename?: 'ZaakStatusType', omschrijving: string, isEindstatus: boolean }, substatussen: Array<{ __typename?: 'ZaakSubStatus', uuid: any, omschrijving: string, tijdstip: string }> }>, statussen: Array<{ __typename?: 'StatusType', omschrijving: string }>, documenten: Array<{ __typename?: 'Document', documentapi: string, bestandsnaam?: string | null, bestandsomvang?: number | null, creatiedatum?: string | null, formaat?: string | null, identificatie?: string | null, titel?: string | null, uuid: any }>, zaakdetails: { __typename?: 'ZaakDetails', data: Array<any>, zaak: string }, resultaat?: { __typename?: 'ZaakResultaat', toelichting?: string | null, resultaattype: { __typename?: 'ResultaatType', omschrijvingGeneriek?: string | null } } | null } };
 
 export type GetZakenQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -2943,7 +2873,7 @@ export type GetZakenQueryVariables = Exact<{
 }>;
 
 
-export type GetZakenQuery = { __typename?: 'Query', getZaken: { __typename?: 'ZaakPage', totalElements: number, totalPages: number, content: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string, omschrijvingGeneriek?: string | null }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean, omschrijvingGeneriek?: string | null } } | null }> } };
+export type GetZakenQuery = { __typename?: 'Query', getZaken: { __typename?: 'ZaakPage', totalElements: number, totalPages: number, content: Array<{ __typename?: 'Zaak', uuid: any, omschrijving: string, identificatie: string, startdatum: any, zaaktype: { __typename?: 'ZaakType', identificatie: string, omschrijving: string }, status?: { __typename?: 'ZaakStatus', statustype: { __typename?: 'ZaakStatusType', isEindstatus: boolean, omschrijving: string } } | null }> } };
 
 export const FormulierFieldsFragmentDoc = gql`
     fragment FormulierFields on TaakFormulierV2 {
@@ -3019,7 +2949,7 @@ export type DeleteUserDigitaleAdresMutationHookResult = ReturnType<typeof useDel
 export type DeleteUserDigitaleAdresMutationResult = Apollo.MutationResult<DeleteUserDigitaleAdresMutation>;
 export type DeleteUserDigitaleAdresMutationOptions = Apollo.BaseMutationOptions<DeleteUserDigitaleAdresMutation, DeleteUserDigitaleAdresMutationVariables>;
 export const DoDirectPaymentDocument = gql`
-    mutation DoDirectPayment($amount: Float!, $identifier: String!, $langId: String, $orderId: String!, $reference: String!, $returnUrl: String) {
+    mutation DoDirectPayment($amount: PositiveFloat!, $identifier: String!, $langId: String, $orderId: String!, $reference: String!, $returnUrl: String) {
   doDirectPayment(
     paymentRequest: {amount: $amount, identifier: $identifier, langId: $langId, orderId: $orderId, reference: $reference, returnUrl: $returnUrl}
   ) {
@@ -3059,7 +2989,7 @@ export type DoDirectPaymentMutationHookResult = ReturnType<typeof useDoDirectPay
 export type DoDirectPaymentMutationResult = Apollo.MutationResult<DoDirectPaymentMutation>;
 export type DoDirectPaymentMutationOptions = Apollo.BaseMutationOptions<DoDirectPaymentMutation, DoDirectPaymentMutationVariables>;
 export const GenerateOgonePaymentDocument = gql`
-    mutation GenerateOgonePayment($amount: Float!, $failureUrl: String, $langId: String, $orderId: String!, $pspId: String!, $reference: String!, $successUrl: String, $title: String) {
+    mutation GenerateOgonePayment($amount: PositiveFloat!, $failureUrl: String, $langId: String, $orderId: String!, $pspId: String!, $reference: String!, $successUrl: String, $title: String) {
   generateOgonePayment(
     paymentRequest: {amount: $amount, failureUrl: $failureUrl, langId: $langId, orderId: $orderId, pspId: $pspId, reference: $reference, successUrl: $successUrl, title: $title}
   ) {
@@ -4757,13 +4687,13 @@ export const GetZaakDocument = gql`
     identificatie
     zaaktype {
       identificatie
-      omschrijvingGeneriek
+      omschrijving
     }
     startdatum
     status {
       datumStatusGezet
       statustype {
-        omschrijvingGeneriek
+        omschrijving
         isEindstatus
       }
       substatussen {
@@ -4775,7 +4705,7 @@ export const GetZaakDocument = gql`
     statusGeschiedenis {
       datumStatusGezet
       statustype {
-        omschrijvingGeneriek
+        omschrijving
         isEindstatus
       }
       substatussen {
@@ -4785,7 +4715,6 @@ export const GetZaakDocument = gql`
       }
     }
     statussen {
-      omschrijvingGeneriek
       omschrijving
     }
     documenten {
@@ -4860,13 +4789,13 @@ export const GetZakenDocument = gql`
       identificatie
       zaaktype {
         identificatie
-        omschrijvingGeneriek
+        omschrijving
       }
       startdatum
       status {
         statustype {
           isEindstatus
-          omschrijvingGeneriek
+          omschrijving
         }
       }
     }

--- a/packages/api/src/mutations/do-direct-payment.ts
+++ b/packages/api/src/mutations/do-direct-payment.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const MUTATION_DO_DIRECT_PAYMENT = gql`
   mutation DoDirectPayment(
-    $amount: Float!
+    $amount: PositiveFloat!
     $identifier: String!
     $langId: String
     $orderId: String!

--- a/packages/api/src/mutations/generate-ogone-payment.ts
+++ b/packages/api/src/mutations/generate-ogone-payment.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const MUTATION_GENERATE_PAYMENT = gql`
   mutation GenerateOgonePayment(
-    $amount: Float!
+    $amount: PositiveFloat!
     $failureUrl: String
     $langId: String
     $orderId: String!

--- a/packages/api/src/queries/get-zaak.ts
+++ b/packages/api/src/queries/get-zaak.ts
@@ -9,13 +9,13 @@ export const QUERY_GET_ZAAK = gql`
       identificatie
       zaaktype {
         identificatie
-        omschrijvingGeneriek
+        omschrijving
       }
       startdatum
       status {
         datumStatusGezet
         statustype {
-          omschrijvingGeneriek
+          omschrijving
           isEindstatus
         }
         substatussen {
@@ -27,7 +27,7 @@ export const QUERY_GET_ZAAK = gql`
       statusGeschiedenis {
         datumStatusGezet
         statustype {
-          omschrijvingGeneriek
+          omschrijving
           isEindstatus
         }
         substatussen {
@@ -37,7 +37,6 @@ export const QUERY_GET_ZAAK = gql`
         }
       }
       statussen {
-        omschrijvingGeneriek
         omschrijving
       }
       documenten {

--- a/packages/api/src/queries/get-zaken.ts
+++ b/packages/api/src/queries/get-zaken.ts
@@ -23,13 +23,13 @@ export const QUERY_GET_ZAKEN = gql`
         identificatie
         zaaktype {
           identificatie
-          omschrijvingGeneriek
+          omschrijving
         }
         startdatum
         status {
           statustype {
             isEindstatus
-            omschrijvingGeneriek
+            omschrijving
           }
         }
       }

--- a/packages/user-interface/src/components/Case.tsx
+++ b/packages/user-interface/src/components/Case.tsx
@@ -15,7 +15,7 @@ const Case = ({ cs, listView }: Props) => {
   const { paths } = useOutletContext<RouterOutletContext>();
   const title = intl.formatMessage({
     id: `case.${cs.zaaktype.identificatie}.title`,
-    defaultMessage: cs.zaaktype.omschrijvingGeneriek || "",
+    defaultMessage: cs.zaaktype.omschrijving || "",
   });
   const appearance = listView
     ? "list"

--- a/packages/user-interface/src/components/StatusHistory.tsx
+++ b/packages/user-interface/src/components/StatusHistory.tsx
@@ -69,23 +69,20 @@ const StatusHistory: FC<StatusHistoryProps> = ({
         <Status
           collapsible
           expandedSteps={[
-            `step-${statuses.findIndex((s) => s.omschrijvingGeneriek === status?.statustype?.omschrijvingGeneriek) + 1}`,
+            `step-${statuses.findIndex((s) => s.omschrijving === status?.statustype?.omschrijving) + 1}`,
           ]}
-          steps={statuses?.map(({ omschrijvingGeneriek }, index) => {
+          steps={statuses?.map(({ omschrijving }, index) => {
             const currentStatus = [status, statusHistory]
               .flat()
-              .find(
-                (s) =>
-                  s?.statustype.omschrijvingGeneriek === omschrijvingGeneriek,
-              );
+              .find((s) => s?.statustype.omschrijving === omschrijving);
 
             return {
               id: `step-${index + 1}`,
               title: intl.formatMessage({
-                id: `case.${caseId}.status.${stringToId(`${omschrijvingGeneriek}`)}`,
-                defaultMessage: omschrijvingGeneriek || "",
+                id: `case.${caseId}.status.${stringToId(`${omschrijving}`)}`,
+                defaultMessage: omschrijving || "",
               }),
-              status: getStepStatus(omschrijvingGeneriek),
+              status: getStepStatus(omschrijving),
               marker: index + 1,
               steps: currentStatus?.substatussen?.map(
                 (sub: ZaakSubStatus, subIndex: number) => ({
@@ -95,9 +92,9 @@ const StatusHistory: FC<StatusHistoryProps> = ({
                     date: sub.tijdstip,
                   }),
                   status:
-                    getStepStatus(omschrijvingGeneriek) === "checked"
+                    getStepStatus(omschrijving) === "checked"
                       ? "checked"
-                      : getStepStatus(omschrijvingGeneriek) === "current" &&
+                      : getStepStatus(omschrijving) === "current" &&
                           subIndex === currentStatus?.substatussen.length - 1
                         ? "current"
                         : "checked",

--- a/packages/user-interface/src/pages/AccountPage.tsx
+++ b/packages/user-interface/src/pages/AccountPage.tsx
@@ -156,8 +156,8 @@ const AccountPage = ({
                   <DescriptionListDetail translate="no">
                     {getStreetString(
                       bedrijf?.embedded?.hoofdvestiging?.adressen?.[0]
-                        .straatnaam,
-                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0].huisnummer?.toString(),
+                        ?.straatnaam,
+                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0]?.huisnummer?.toString(),
                       undefined,
                       undefined,
                     )}
@@ -171,8 +171,9 @@ const AccountPage = ({
                 detail: (
                   <DescriptionListDetail translate="no">
                     {getPostalCodeCityString(
-                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0].postcode,
-                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0].plaats,
+                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0]
+                        ?.postcode,
+                      bedrijf?.embedded?.hoofdvestiging?.adressen?.[0]?.plaats,
                     )}
                   </DescriptionListDetail>
                 ),

--- a/packages/user-interface/src/pages/CaseDetailsPage.tsx
+++ b/packages/user-interface/src/pages/CaseDetailsPage.tsx
@@ -156,7 +156,7 @@ const CaseDetailsPage = ({ showContactTimeline = false }: CasePageProps) => {
     }
 
     return array;
-  }, [caseData, currentLocale]);
+  }, [caseData?.getZaak, intl, formatDate]);
 
   const contactItems = React.useMemo(() => {
     if (!momentsData) return [];
@@ -211,8 +211,7 @@ const CaseDetailsPage = ({ showContactTimeline = false }: CasePageProps) => {
             !loading &&
             intl.formatMessage({
               id: `case.${caseData?.getZaak.zaaktype.identificatie}.title`,
-              defaultMessage:
-                caseData?.getZaak.zaaktype.omschrijvingGeneriek || "",
+              defaultMessage: caseData?.getZaak.zaaktype.omschrijving || "",
             })
           }
         />

--- a/packages/user-interface/src/tests/pages/CaseDetailsPage.test.tsx
+++ b/packages/user-interface/src/tests/pages/CaseDetailsPage.test.tsx
@@ -37,7 +37,7 @@ describe("CaseDetailsPage", () => {
     await waitForElementToBeRemoved(skeleton);
 
     expect(screen.getByText("Certificaat WWJB")).toBeVisible();
-    expect(screen.getByText("case.B0756.title")).toBeVisible();
+    expect(screen.getByText("Bezwaarschrift")).toBeVisible();
     expect(screen.getByText("ZAAK-2023-0000007947")).toBeVisible();
     expect(screen.getByText("Betaalgeschiedenis 2")).toBeVisible();
     expect(screen.getByText("Kamillestraat 22")).toBeVisible();


### PR DESCRIPTION
---

### Description of changes

- Updated to use 'omschrijving' as the default fallback for `zaakType` and `statusType`.
- Fixed out-of-sync GraphQL queries.
- Resolved potential null issues in the codebase.